### PR TITLE
nodeJs < 14 support

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -8,7 +8,7 @@ const download = require("download");
   switch (process.argv[2]) {
     case "postinstall":
       const version =
-        require(path.join(project, "package.json")).caddy ??
+        require(path.join(project, "package.json")).caddy ||
         (
           await got(
             "https://api.github.com/repos/caddyserver/caddy/releases/latest"


### PR DESCRIPTION
simple change to support much more nodeJs versions
the falsy check is maybe the better solution instead a nullish check (empty string)